### PR TITLE
Fix PropType of _app.js

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,6 +22,6 @@ function MyApp({ Component, pageProps }) {
 export default MyApp
 
 MyApp.propTypes = {
-  Component: PropTypes.element,
+  Component: PropTypes.elementType,
   pageProps: PropTypes.object
 }


### PR DESCRIPTION
# Description
With `PropTypes.element` the app was returning an error when passing each page component, changing that to `PropTypes.elementType` solved the issue.
 
# Testing
N/A
  
## Screenshots 
N/A
